### PR TITLE
feat(Persistence):added persistence mechanism

### DIFF
--- a/apps/events-router-service/build.gradle
+++ b/apps/events-router-service/build.gradle
@@ -25,9 +25,26 @@ dependencies {
   implementation 'org.springframework.kafka:spring-kafka:3.1.1'
   implementation project(':shared:core-common')
   implementation project(':shared:core-consumer')
+  implementation project(':shared:core-persistence')
   implementation 'junit:junit:4.13.2'
+  implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+  implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+  annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+
   testImplementation 'org.springframework.kafka:spring-kafka-test:3.1.1'
   testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+}
+
+def additionalCompilerArgs = [
+  "-Amapstruct.defaultComponentModel=spring",
+  "-Amapstruct.unmappedTargetPolicy=ERROR",
+  "-Amapstruct.defaultInjectionStrategy=constructor"
+]
+
+compileJava {
+  options.encoding = 'UTF-8'
+  options.compilerArgs += additionalCompilerArgs
 }
 
 tasks.named('test') {

--- a/apps/events-router-service/docker-compose.yml
+++ b/apps/events-router-service/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.0
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.0
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  kafkdrop:
+    image: obsidiandynamics/kafdrop:latest
+    container_name: kafkdrop
+    ports:
+      - "9000:9000"
+    depends_on:
+      - kafka
+    environment:
+      KAFKA_BROKERCONNECT: kafka:9092
+      JVM_OPTS: "-Xms32m -Xmx128m"
+      SERVER_SERVLET_CONTEXT_PATH: "/kafkdrop/"
+
+  mongodb:
+    image: mongo:latest
+    container_name: mongodb
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+    volumes:
+      - mongo-data:/data/db

--- a/apps/events-router-service/src/main/java/com/tech/engg5/events/router/repository/BookEventRawMongoRepository.java
+++ b/apps/events-router-service/src/main/java/com/tech/engg5/events/router/repository/BookEventRawMongoRepository.java
@@ -1,0 +1,9 @@
+package com.tech.engg5.events.router.repository;
+
+import com.tech.engg5.persistence.model.mongo.BookEventRaw;
+import com.tech.engg5.persistence.repository.AbstractMongoPersistenceRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookEventRawMongoRepository extends AbstractMongoPersistenceRepository<BookEventRaw, String> {
+}

--- a/apps/events-router-service/src/main/java/com/tech/engg5/events/router/service/BookRawEventService.java
+++ b/apps/events-router-service/src/main/java/com/tech/engg5/events/router/service/BookRawEventService.java
@@ -1,0 +1,47 @@
+package com.tech.engg5.events.router.service;
+
+import com.tech.engg5.common.model.BookEventPayload;
+import com.tech.engg5.events.router.repository.BookEventRawMongoRepository;
+import com.tech.engg5.persistence.model.mongo.Audit;
+import com.tech.engg5.persistence.model.mongo.BookEventRaw;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+public class BookRawEventService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BookRawEventService.class);
+
+  @Autowired
+  BookEventRawMongoRepository bookEventRawMongoRepository;
+
+  public void saveOrUpdateRawEvent(BookEventPayload payload, long offset, int partitionNumber) {
+
+    Optional<BookEventRaw> existingRecord = bookEventRawMongoRepository.findById(payload.getAlertDataId());
+
+    if (existingRecord.isPresent()) {
+      LOG.info("Record with alertId - [{}] already exists within database.", payload.getAlertDataId());
+    } else {
+      LOG.info("Record with alertId - [{}] does not exist within database. Saving the record.", payload.getAlertDataId());
+
+      BookEventRaw record = BookEventRaw.builder()
+        .alertId(payload.getAlertDataId())
+        .bookEvent(payload)
+        .audit(Audit.builder()
+          .creationDate(Instant.now())
+          .lastModifiedDate(Instant.now())
+          .lastModifiedBy("EVENT_ROUTER_SERVICE")
+          .messageOffset(offset)
+          .messagePartition(partitionNumber)
+          .build())
+        .build();
+
+      bookEventRawMongoRepository.save(record);
+    }
+  }
+}

--- a/apps/events-router-service/src/main/resources/application.yml
+++ b/apps/events-router-service/src/main/resources/application.yml
@@ -26,6 +26,11 @@ management:
 spring:
   application:
     name: events-router-service
+  data:
+    mongodb:
+      database: localEnv
+      host: localhost
+      port: 27017
   kafka:
     bootstrap-servers: localhost:9092
     consumer:
@@ -41,6 +46,7 @@ spring:
     properties:
       spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
       spring.deserializer.value.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+      spring.json.trusted.packages: "*"
 
 events:
   router:

--- a/apps/events-router-service/src/test/java/com/tech/engg5/events/router/Fixture.java
+++ b/apps/events-router-service/src/test/java/com/tech/engg5/events/router/Fixture.java
@@ -1,0 +1,28 @@
+package com.tech.engg5.events.router;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.experimental.FieldDefaults;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.InputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toByteArray;
+
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public enum Fixture {
+  RAW_REQUESTS("raw");
+
+  String path;
+
+  @SneakyThrows
+  public String loadFixture(String filename) {
+    String fixturePath = "fixtures/" + this.path + '/' + filename;
+    try (InputStream inputStream = new ClassPathResource(fixturePath).getInputStream()) {
+      return new String(toByteArray(inputStream), UTF_8);
+    }
+  }
+}

--- a/apps/events-router-service/src/test/java/com/tech/engg5/events/router/IntegrationTestBase.java
+++ b/apps/events-router-service/src/test/java/com/tech/engg5/events/router/IntegrationTestBase.java
@@ -1,0 +1,44 @@
+package com.tech.engg5.events.router;
+
+import com.tech.engg5.persistence.model.mongo.Audit;
+import org.assertj.core.api.RecursiveComparisonAssert;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class IntegrationTestBase {
+
+  @Autowired
+  protected MongoTemplate mongoTemplate;
+
+  protected static final List<String> DEFAULT_FIELDS_TO_IGNORE_RAW_AUDIT =
+    asList(Audit.Fields.creationDate, Audit.Fields.lastModifiedDate);
+
+  protected static final Duration EXPECTING_MESSAGES_TIMEOUT = Duration.ofSeconds(500);
+
+  @SafeVarargs
+  protected final <T> void thenExpectEntriesInRaw(Class<T> type, T... expectedEntries) {
+    thenExpectDatabaseEntries(type, DEFAULT_FIELDS_TO_IGNORE_RAW_AUDIT, expectedEntries);
+  }
+
+  @SafeVarargs
+  protected final <T> void thenExpectDatabaseEntries(Class<T> type, List<String> fieldsToIgnore, T... expectedEntries) {
+    await().atMost(EXPECTING_MESSAGES_TIMEOUT)
+      .until(() -> mongoTemplate.findAll(type).size() == expectedEntries.length);
+
+    List<T> entriesInCollection = mongoTemplate.findAll(type);
+    RecursiveComparisonAssert<?> assertion = assertThat(entriesInCollection).usingRecursiveComparison()
+      .ignoringAllOverriddenEquals()
+      .ignoringFields(fieldsToIgnore.toArray(new String[0]))
+      .ignoringCollectionOrder();
+
+    assertion.isEqualTo(Arrays.asList(expectedEntries));
+  }
+}

--- a/apps/events-router-service/src/test/java/com/tech/engg5/events/router/service/BookRawEventServiceTest.java
+++ b/apps/events-router-service/src/test/java/com/tech/engg5/events/router/service/BookRawEventServiceTest.java
@@ -1,0 +1,75 @@
+package com.tech.engg5.events.router.service;
+
+import com.tech.engg5.common.model.BookEventPayload;
+import com.tech.engg5.events.router.repository.BookEventRawMongoRepository;
+import com.tech.engg5.persistence.model.mongo.Audit;
+import com.tech.engg5.persistence.model.mongo.BookEventRaw;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class BookRawEventServiceTest {
+
+  private BookRawEventService bookRawEventService;
+
+  @Mock
+  private BookEventRawMongoRepository bookEventRawMongoRepository;
+
+  @BeforeEach
+  @AfterEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    bookRawEventService = new BookRawEventService();
+    bookRawEventService.bookEventRawMongoRepository = bookEventRawMongoRepository;
+  }
+
+  @Test
+  @DisplayName("Verify the saveOrUpdateRawEvent method saves a new record when it does not exist in the database")
+  void shouldSaveRawMessage_toDatabase() {
+
+    String alertId = "test-alert-id";
+    BookEventPayload payload = BookEventPayload.builder().alertDataId(alertId).build();
+
+    when(bookEventRawMongoRepository.findById(alertId)).thenReturn(Optional.empty());
+    bookRawEventService.saveOrUpdateRawEvent(payload, 123L, 1);
+
+    ArgumentCaptor<BookEventRaw> argumentCaptor = ArgumentCaptor.forClass(BookEventRaw.class);
+    verify(bookEventRawMongoRepository, times(1)).save(argumentCaptor.capture());
+    BookEventRaw savedRecord = argumentCaptor.getValue();
+
+    assertThat(savedRecord.getAlertId()).isEqualTo(alertId);
+    assertThat(savedRecord.getAudit().getMessageOffset()).isEqualTo(123L);
+    assertThat(savedRecord.getAudit().getMessagePartition()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("Verify the saveOrUpdateRawEvent method does not save a record when it already exists in the database")
+  void shouldReturnWhenRecordExists() {
+    String alertId = "test-alert-id";
+    BookEventPayload payload = BookEventPayload.builder().alertDataId(alertId).build();
+
+    BookEventRaw existingRecord = BookEventRaw.builder().alertId(alertId).bookEvent(payload)
+      .audit(Audit.builder().messageOffset(123L).messagePartition(1).build())
+      .build();
+
+    when(bookEventRawMongoRepository.findById(alertId)).thenReturn(Optional.of(existingRecord));
+
+    bookRawEventService.saveOrUpdateRawEvent(payload, 123L, 1);
+
+    verify(bookEventRawMongoRepository, never()).save(any(BookEventRaw.class));
+    verify(bookEventRawMongoRepository, times(1)).findById(alertId);
+  }
+}

--- a/apps/events-router-service/src/test/resources/application-test.yml
+++ b/apps/events-router-service/src/test/resources/application-test.yml
@@ -1,0 +1,18 @@
+spring:
+  data:
+    mongodb:
+      port: 27017
+  kafka:
+    bootstrap-servers: localhost:9092
+
+events:
+  router:
+    consumer:
+      topic: demo-topic
+      group-id: demo-group
+      auto-startup: true
+      seek-type: beginning
+      rewind-messages: 1
+      offset: 0
+      partition-number: -1
+      pause-consuming: false

--- a/apps/events-router-service/src/test/resources/fixtures/raw/raw-message.json
+++ b/apps/events-router-service/src/test/resources/fixtures/raw/raw-message.json
@@ -1,0 +1,25 @@
+{
+  "alertDataId": "tua12da-12132nd1-12poij",
+  "bookInfo": {
+    "bookId": "abc123-xyz456",
+    "bookName": "World Book Dictionary",
+    "bookGenre": [
+      "Knowledge"
+    ],
+    "bookPublisher": [
+      "ABC Incorporation"
+    ],
+    "bookPublishingDate": "09-10-1992",
+    "bookAuthor": "John Doe"
+  },
+  "transactionType": "PAYMENT_CANCELLED",
+  "bookEventInfo": {
+    "transactionCancelled": {
+      "transactionId": "1oi2h1iu2hbo1hiop1he",
+      "transactionAmount": "302",
+      "transactionMethodLastFourDigits": "4123",
+      "transactionDate": "10-04-2025",
+      "transactionPayeeName": "Daniels J"
+    }
+  }
+}

--- a/buildSrc/src/main/groovy/tech-engg5.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/tech-engg5.library-conventions.gradle
@@ -54,15 +54,29 @@ dependencies {
 
   implementation 'org.springframework.kafka:spring-kafka:3.1.9'
   implementation 'org.springframework.cloud:spring-cloud-starter:4.0.2'
+  implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+  implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
   compileOnly 'org.projectlombok:lombok:1.18.26'
   annotationProcessor 'org.projectlombok:lombok:1.18.26'
+  annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
   testCompileOnly 'org.projectlombok:lombok:1.18.26'
   testAnnotationProcessor 'org.projectlombok:lombok:1.18.26'
 
   testImplementation 'org.springframework.kafka:spring-kafka-test:3.1.9'
   testImplementation 'org.springframework.boot:spring-boot-starter-test:3.2.4'
+}
+
+def additionalCompilerArgs = [
+  "-Amapstruct.defaultComponentModel=spring",
+  "-Amapstruct.unmappedTargetPolicy=ERROR",
+  "-Amapstruct.defaultInjectionStrategy=constructor"
+]
+
+compileJava {
+  options.encoding = 'UTF-8'
+  options.compilerArgs += additionalCompilerArgs
 }
 
 task copyNativeDeps(type: Copy) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,3 @@
 rootProject.name = 'event-platform-mono'
-include 'shared:core-common', 'shared:core-consumer'
+include 'shared:core-common', 'shared:core-consumer', 'shared:core-persistence'
 include 'apps:events-router-service'
-

--- a/shared/core-common/src/main/java/com/tech/engg5/common/exception/DatabaseException.java
+++ b/shared/core-common/src/main/java/com/tech/engg5/common/exception/DatabaseException.java
@@ -1,0 +1,8 @@
+package com.tech.engg5.common.exception;
+
+public class DatabaseException extends RuntimeException {
+
+  public DatabaseException(String message) { super(message); }
+
+  public DatabaseException(String message, Throwable cause) { super(message, cause); }
+}

--- a/shared/core-common/src/main/java/com/tech/engg5/common/model/BookEventInfo.java
+++ b/shared/core-common/src/main/java/com/tech/engg5/common/model/BookEventInfo.java
@@ -2,12 +2,16 @@ package com.tech.engg5.common.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class BookEventInfo {
 

--- a/shared/core-common/src/main/java/com/tech/engg5/common/model/BookEventPayload.java
+++ b/shared/core-common/src/main/java/com/tech/engg5/common/model/BookEventPayload.java
@@ -2,12 +2,16 @@ package com.tech.engg5.common.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class BookEventPayload {
 

--- a/shared/core-common/src/main/java/com/tech/engg5/common/model/BookEventTransactionCancelled.java
+++ b/shared/core-common/src/main/java/com/tech/engg5/common/model/BookEventTransactionCancelled.java
@@ -1,13 +1,13 @@
 package com.tech.engg5.common.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 import lombok.experimental.FieldDefaults;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class BookEventTransactionCancelled {
 

--- a/shared/core-common/src/main/java/com/tech/engg5/common/model/BookInfo.java
+++ b/shared/core-common/src/main/java/com/tech/engg5/common/model/BookInfo.java
@@ -2,14 +2,18 @@ package com.tech.engg5.common.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
 import java.util.List;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class BookInfo {
 

--- a/shared/core-consumer/src/main/java/com/tech/engg5/consumer/service/AbstractKafkaConsumerService.java
+++ b/shared/core-consumer/src/main/java/com/tech/engg5/consumer/service/AbstractKafkaConsumerService.java
@@ -36,8 +36,7 @@ public abstract class AbstractKafkaConsumerService implements ConsumerSeekAware 
     LOG.info("Received message: [{}], from offset - [{}]", message, metadata.offset());
     persistMessage(message, metadata, key);
     ack.acknowledge();
-    LOG.info("Acknowledged message: [{}], from offset - [{}], partitionNumber - [{}]", message, metadata.offset(),
-      metadata.partition());
+    LOG.info("Acknowledged from offset - [{}], partitionNumber - [{}]", metadata.offset(), metadata.partition());
 
     if (pauseConsuming()) {
       LOG.info("Stop consuming messages.");

--- a/shared/core-consumer/src/test/java/com/tech/engg5/consumer/service/AbstractKafkaConsumerServiceTest.java
+++ b/shared/core-consumer/src/test/java/com/tech/engg5/consumer/service/AbstractKafkaConsumerServiceTest.java
@@ -23,8 +23,15 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -106,7 +113,7 @@ public class AbstractKafkaConsumerServiceTest {
 
     TestConsumer t = new TestConsumer(provider);
     t.assignPartition(assignmentsHavingOneTopic, callback);
-    verify(callback, Mockito.times(0)).seekRelative(anyString(), anyInt(), anyLong(), anyBoolean());
+    verify(callback, times(0)).seekRelative(anyString(), anyInt(), anyLong(), anyBoolean());
   }
 
   @Test
@@ -117,7 +124,7 @@ public class AbstractKafkaConsumerServiceTest {
     provider.setRewindCount(100);
     provider.setSeekType(ConsumerConstants.REWIND);
     consumer.assignPartition(assignmentsHavingOneTopic, callback);
-    verify(callback, Mockito.times(0)).seekRelative(anyString(), anyInt(), anyLong(), anyBoolean());
+    verify(callback, times(0)).seekRelative(anyString(), anyInt(), anyLong(), anyBoolean());
   }
 
   @Test
@@ -128,7 +135,7 @@ public class AbstractKafkaConsumerServiceTest {
     provider.setRewindCount(-100);
     provider.setSeekType(ConsumerConstants.REWIND);
     consumer.assignPartition(assignmentsHavingOneTopic, callback);
-    verify(callback, Mockito.times(1)).seekRelative("test", 1, -100, true);
+    verify(callback, times(1)).seekRelative("test", 1, -100, true);
   }
 
   @Test
@@ -139,7 +146,7 @@ public class AbstractKafkaConsumerServiceTest {
     provider.setRewindCount(-100);
     provider.setSeekType(ConsumerConstants.REWIND_FROM_END);
     consumer.assignPartition(assignmentsHavingOneTopic, callback);
-    verify(callback, Mockito.times(1)).seekRelative("test", 1, -100, false);
+    verify(callback, times(1)).seekRelative("test", 1, -100, false);
   }
 
   @Test
@@ -150,7 +157,7 @@ public class AbstractKafkaConsumerServiceTest {
     provider.setRewindCount(100);
     provider.setSeekType(ConsumerConstants.REWIND_FROM_END);
     consumer.assignPartition(assignmentsHavingOneTopic, callback);
-    verify(callback, Mockito.times(0)).seekRelative(anyString(), anyInt(), anyLong(), anyBoolean());
+    verify(callback, times(0)).seekRelative(anyString(), anyInt(), anyLong(), anyBoolean());
   }
 
   @Test

--- a/shared/core-persistence/build.gradle
+++ b/shared/core-persistence/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+  id 'tech-engg5.library-conventions'
+}
+
+group = 'com.tech.engg5.persistence'
+
+repositories {
+  gradlePluginPortal()
+  mavenCentral()
+}
+
+dependencies {
+  api project(':shared:core-common')
+  implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+
+  annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+
+  testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+  useJUnitPlatform()
+}
+
+bootJar {
+  enabled = false
+}

--- a/shared/core-persistence/src/main/java/com/tech/engg5/persistence/model/mongo/Audit.java
+++ b/shared/core-persistence/src/main/java/com/tech/engg5/persistence/model/mongo/Audit.java
@@ -1,0 +1,29 @@
+package com.tech.engg5.persistence.model.mongo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.FieldNameConstants;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldNameConstants
+@FieldDefaults(level = lombok.AccessLevel.PRIVATE)
+public class Audit {
+
+  Instant creationDate;
+
+  @LastModifiedDate
+  Instant lastModifiedDate;
+
+  String lastModifiedBy;
+  long messageOffset;
+  int messagePartition;
+}

--- a/shared/core-persistence/src/main/java/com/tech/engg5/persistence/model/mongo/BookEventRaw.java
+++ b/shared/core-persistence/src/main/java/com/tech/engg5/persistence/model/mongo/BookEventRaw.java
@@ -1,0 +1,26 @@
+package com.tech.engg5.persistence.model.mongo;
+
+import com.tech.engg5.common.model.BookEventPayload;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.FieldNameConstants;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldNameConstants
+@FieldDefaults(level = lombok.AccessLevel.PRIVATE)
+@Document(collection = "book-events-raw")
+public class BookEventRaw {
+
+  @Id
+  String alertId;
+  BookEventPayload bookEvent;
+  Audit audit;
+}

--- a/shared/core-persistence/src/main/java/com/tech/engg5/persistence/repository/AbstractMongoPersistenceRepository.java
+++ b/shared/core-persistence/src/main/java/com/tech/engg5/persistence/repository/AbstractMongoPersistenceRepository.java
@@ -1,0 +1,22 @@
+package com.tech.engg5.persistence.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+/**
+ * Abstract base repository interface for MongoDB entities.
+ * <p>
+ *   This interface is marked with {@link NoRepositoryBean}, indicating that Spring Data should not instantiate
+ *   it directly as Spring Bean. Instead, it is meant to be extended by other concrete repository interfaces to
+ *   share common functionality.
+ * </p>
+ * Extend this interface in the application-specific repositories to inherit standard MonogoDB CRUD operations and
+ * centralize cross-cutting concerns.
+ *
+ * @param <T>  the domain or entity type the repository manages
+ * @param <ID> the type of the entity's the repository manages
+ */
+
+@NoRepositoryBean
+public interface AbstractMongoPersistenceRepository<T, ID> extends MongoRepository<T, ID> {
+}


### PR DESCRIPTION
This PR includes the following changes -

- Mongo collection model class. Collection name -> "**book-events-raw**"
- Abstract mongo repository interface in shared persistence library for reusability
- Mongo repository implementation in apps.events-router-service
- Service implementation for the mongo repository in apps.events-router-service
- Deserializing mechanism to convert incoming string messages to java model class
- Updated model classes for deserializing from string to object (FIX)
- Updated existing test cases
- Added test cases for new service class